### PR TITLE
Update panel to 0.12.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.12.1" %}
+{% set version = "0.12.6" %}
 
 package:
   name: panel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: e4898d60abdb82f8a429df7f59dbf8bcaf7e19b3e633555512ceb4ce06678458
+  sha256: 97e158e8eb941f88d71929407f9455c903b5e18d89969db8ce8af66036f46b53
 
 build:
   number: 0
@@ -18,30 +18,30 @@ build:
 
 requirements:
   host:
-    - python >=3
+    - python
     - pip
-    # These are also needed at build time.
-    - pyct >=0.4.4
-    - param >=1.10.0
-    - bokeh >=2.3,<2.4
-    - nodejs >=10.13.0
-    - pyviz_comms >=0.7.4
-    - requests
-    - packaging
-    - tqdm
-    - bleach
     - setuptools >=30.3.0
     - wheel
+    # These are also needed at build time.
+    - bleach
+    - bokeh >=2.4.0,<2.5.0
+    - pyct >=0.4.4
+    - nodejs >=10.13.0
+    - packaging
+    - param >=1.9.2
+    - pyviz_comms >=0.6.0
+    - requests
+    - tqdm >=4.48.0
   run:
-    - python >=3
-    - bokeh >=2.3,<2.4
+    - python >=3.6
+    - bleach
+    - bokeh >=2.4,<2.5
     - markdown
     - param >=1.10.0
     - pyct >=0.4.4
     - pyviz_comms >=0.7.4
-    - tqdm
     - requests
-    - bleach
+    - tqdm >=4.48.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
     # These are also needed at build time.
     - bleach
-    - bokeh >=2.4.0,<2.5.0
+    - bokeh >=2.3.0,<2.4.0
     - pyct >=0.4.4
     - nodejs >=10.13.0
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - param >=1.10.0
     - pyviz_comms >=0.7.4
     - requests
-    - tqdm >=4.48.0
+    - tqdm
   run:
     - python >=3.6
     - bleach

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - nodejs >=10.13.0
     - packaging
     - param >=1.10.0
-    - pyviz_comms >=0.6.0
+    - pyviz_comms >=0.7.4
     - requests
     - tqdm >=4.48.0
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - bleach
     - bokeh >=2.4.0,<2.5.0
     - pyct >=0.4.4
-    - nodejs >=10.13.0
     - packaging
     - param >=1.9.2
     - pyviz_comms >=0.6.0
@@ -53,6 +52,8 @@ test:
   commands:
     - pip check
     - panel --help
+  downstreams:
+    - holoviews
 
 about:
   home: https://panel.holoviz.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
   number: 0
+  # nodejs currently isn't availeble on s390x
+  skip: True  # [linux and s390x]
   noarch: python
   entry_points:
     - panel = panel.command:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,6 @@ requirements:
     - pip
     - setuptools >=30.3.0
     - wheel
-    - nodejs >=14
-    - yaml
     # These are also needed at build time.
     - bleach
     - bokeh >=2.4.0,<2.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,11 @@ requirements:
     - wheel
     # These are also needed at build time.
     - bleach
-    - bokeh >=2.3.0,<2.4.0
+    - bokeh >=2.4.0,<2.5.0
     - pyct >=0.4.4
     - nodejs >=10.13.0
     - packaging
-    - param >=1.9.2
+    - param >=1.10.0
     - pyviz_comms >=0.6.0
     - requests
     - tqdm >=4.48.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     # These are also needed at build time.
     - bleach
     - bokeh >=2.4.0,<2.5.0
+    - nodejs >=14.0.0
     - pyct >=0.4.4
     - packaging
     - param >=1.9.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,16 +22,18 @@ requirements:
     - pip
     - setuptools >=30.3.0
     - wheel
+    - nodejs >=14
+    - yaml
     # These are also needed at build time.
     - bleach
     - bokeh >=2.4.0,<2.5.0
     - pyct >=0.4.4
     - nodejs >=10.13.0
     - packaging
-    - param >=1.10.0
-    - pyviz_comms >=0.7.4
+    - param >=1.9.2
+    - pyviz_comms >=0.6.0
     - requests
-    - tqdm
+    - tqdm >=4.48.0
   run:
     - python >=3.6
     - bleach
@@ -41,7 +43,7 @@ requirements:
     - pyct >=0.4.4
     - pyviz_comms >=0.7.4
     - requests
-    - tqdm
+    - tqdm >=4.48.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - pyct >=0.4.4
     - pyviz_comms >=0.7.4
     - requests
-    - tqdm >=4.48.0
+    - tqdm
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
   run:
     - python >=3.6
     - bleach
-    - bokeh >=2.4,<2.5
+    - bokeh >=2.4.0,<2.5.0
     - markdown
     - param >=1.10.0
     - pyct >=0.4.4


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/holoviz/panel/issues
Github releases:  https://github.com/holoviz/panel/releases
Upstream Changelog: https://github.com/holoviz/panel/blob/v0.12.6/CHANGELOG.md
License: https://github.com/holoviz/panel/blob/v0.12.6/LICENSE.txt
Upstream setup.py:  https://github.com/holoviz/panel/blob/v0.12.6/setup.py
Upstream pyproject.toml:  https://github.com/holoviz/panel/blob/v0.12.6/pyproject.toml

The package panel is mentioned inside the packages:
holoviews |

Actions:
1. Update and reorder dependencies for readability
2. Fix python in `host`: `python`, and in `run`: `python >=3.6`
3. Use `downstreams` for testing the downstream package `holoviews`

Result:
- all-succeeded, except ppc64le


