### PR TITLE
panel 0.12.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
 
 build:
   number: 0
-  # nodejs currently isn't availeble on s390x
-  skip: True  # [linux and s390x]
+  # nodejs currently isn't available on s390x
   noarch: python
   entry_points:
     - panel = panel.command:main
@@ -22,7 +21,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=30.3.0
+    - setuptools >=42,<61
     - wheel
     # These are also needed at build time.
     - bleach
@@ -43,6 +42,7 @@ requirements:
     - pyct >=0.4.4
     - pyviz_comms >=0.7.4
     - requests
+    - setuptools >=42,<61
     - tqdm >=4.48.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.12.6" %}
+{% set version = "0.12.7" %}
 
 package:
   name: panel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: 97e158e8eb941f88d71929407f9455c903b5e18d89969db8ce8af66036f46b53
+  sha256: 119b525c954df0d630e7bc7ef2cb7e50b406cca73a4caa823c43e49d58b52ebb
 
 build:
   number: 0


### PR DESCRIPTION
Update panel to 0.12.7

Bug Tracker: new open issues https://github.com/holoviz/panel/issues
Github releases: https://github.com/holoviz/panel/releases
Upstream Changelog: https://github.com/holoviz/panel/blob/v0.12.7/CHANGELOG.md
License: https://github.com/holoviz/panel/blob/v0.12.7/LICENSE.txt
Upstream setup.py: https://github.com/holoviz/panel/blob/v0.12.7/setup.py
Upstream pyproject.toml: https://github.com/holoviz/panel/blob/v0.12.7/pyproject.toml

The package panel is mentioned inside the packages:
holoviews |

Actions:
1. Update pinnings for setuptools in host
2. Add setuptools in run