### PR TITLE
panel 0.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,8 +53,9 @@ test:
   commands:
     - pip check
     - panel --help
-  downstreams:
-    - holoviews
+  downstreams:   # [not win]
+    # CI issues on win
+    - holoviews  # [not win]
 
 about:
   home: https://panel.holoviz.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.12.7" %}
+{% set version = "0.13.0" %}
 
 package:
   name: panel
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: 119b525c954df0d630e7bc7ef2cb7e50b406cca73a4caa823c43e49d58b52ebb
+  sha256: 703c448bc83d6db9b72b0605af7a7403136310f84137d32d9228963b8abc2d74
 
 build:
   number: 0
   # nodejs currently isn't available on s390x
-  noarch: python
+  skip: True  # [py<36 or s390x]
   entry_points:
     - panel = panel.command:main
   script:
@@ -21,7 +21,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=42,<61
+    - setuptools >=42
     - wheel
     # These are also needed at build time.
     - bleach
@@ -34,15 +34,14 @@ requirements:
     - requests
     - tqdm >=4.48.0
   run:
-    - python >=3.6
+    - python
     - bleach
     - bokeh >=2.4.0,<2.5.0
     - markdown
-    - param >=1.10.0
+    - param >=1.12.0
     - pyct >=0.4.4
     - pyviz_comms >=0.7.4
     - requests
-    - setuptools >=42,<61
     - tqdm >=4.48.0
 
 test:
@@ -51,7 +50,6 @@ test:
     - panel.io
   requires:
     - pip
-    - colorama
   commands:
     - pip check
     - panel --help


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/holoviz/panel/issues
Github releases: https://github.com/holoviz/panel/releases
Upstream Changelog: https://github.com/holoviz/panel/blob/v0.13.0/CHANGELOG.md
License: https://github.com/holoviz/panel/blob/v0.13.0/LICENSE.txt
Upstream setup.py: https://github.com/holoviz/panel/blob/v0.13.0/setup.py
Upstream pyproject.toml: https://github.com/holoviz/panel/blob/v0.13.0/pyproject.toml

The package panel is mentioned inside the packages:
holoviews |

Actions:

1. Remove `noarch: python`
2. Skip `py<36` and `s390x`
3. Remove an upper bound for `setuptools` in `host`
4. Fix `python` in `run`
5. Update pinning for `param` and remove `setuptools` from `run`
6. Remove `colorama` from `test/requires`