### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.1" %}
+{% set version = "1.2.1" %}
 
 package:
   name: panel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: 956f053f2b3674516c0fe928c27bf2e7080e0ee669dd3e05f27b9bad19cdf24f
+  sha256: abf2e601c609c610fdbac4929a046afae5874e06ea397c9f28262f56668f1b24
 
 build:
   number: 0
@@ -25,7 +25,7 @@ requirements:
     - wheel
     # These are also needed at build time.
     - bleach
-    - bokeh 3.1.1
+    - bokeh 3.2.0
     - nodejs
     - pyct
     - packaging
@@ -37,14 +37,14 @@ requirements:
     - python
     - bleach
     - packaging
-    - bokeh >=3.1.1,<3.2
+    - bokeh >=3.1.1,<3.3
     - markdown
     - param >=1.12.0
     - pyviz_comms >=0.7.4
     - requests
     - tqdm >=4.48.0
     - typing_extensions
-    - markdown-it-py <3
+    - markdown-it-py
     - linkify-it-py
     - mdit-py-plugins
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,20 +19,21 @@ build:
 
 requirements:
   host:
+    - nodejs
     - python
     - pip
     - setuptools
     - wheel
     # These are also needed at build time.
-    - bleach
-    - bokeh 3.2.0
-    - nodejs
-    - pyct
-    - packaging
-    - param
-    - pyviz_comms
-    - requests
-    - tqdm
+    - bleach 4.1.0
+    - bokeh 3.1.1 # [py<39]
+    - bokeh 3.2.0 # [py>=39]
+    - pyct 0.4.8
+    - packaging 22.0
+    - param 1.12.1
+    - pyviz_comms 2.3.0
+    - requests 2.31.1
+    - tqdm 4.65.0
   run:
     - python
     - bleach
@@ -77,4 +78,3 @@ extra:
     - philippjfr
   skip-lints:
     - python_build_tool_in_run
-    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - pyct 0.5.0
     - param 1.13.0
     - pyviz_comms 2.3.0
-    - nodejs 16.6.1
+    - nodejs 16.13.1
     - requests 2.31.0
     - tqdm 4.65.0
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - nodejs
+    - packaging
     - python
     - pip
     - setuptools
@@ -28,11 +28,11 @@ requirements:
     - bleach 4.1.0
     - bokeh 3.1.1 # [py<39]
     - bokeh 3.2.0 # [py>=39]
-    - pyct 0.4.8
-    - packaging 22.0
+    - pyct 0.5.0
     - param 1.12.1
     - pyviz_comms 2.3.0
-    - requests 2.31.1
+    - nodejs 16.6.1
+    - requests 2.31.0
     - tqdm 4.65.0
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - bokeh 3.1.1 # [py<39]
     - bokeh 3.2.0 # [py>=39]
     - pyct 0.5.0
-    - param 1.12.1
+    - param 1.13.0
     - pyviz_comms 2.3.0
     - nodejs 16.6.1
     - requests 2.31.0


### PR DESCRIPTION
Simple version bump along with unpin of `bokeh` and `markdown-it-py` versions.