### PR TITLE
Update to 1.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.1" %}
+{% set version = "1.2.2" %}
 
 package:
   name: panel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: abf2e601c609c610fdbac4929a046afae5874e06ea397c9f28262f56668f1b24
+  sha256: 98996d19cd3da21c6dae2c32d26599b19d2f54033e3f00c8d2f3665e5027f0e8
 
 build:
   number: 0


### PR DESCRIPTION
Simple version bump, as done on [conda-forge](https://github.com/conda-forge/panel-feedstock/pull/73/files).