### PR TITLE
Bump panel version to 1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.2" %}
+{% set version = "1.3.0" %}
 
 package:
   name: panel
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: 98996d19cd3da21c6dae2c32d26599b19d2f54033e3f00c8d2f3665e5027f0e8
+  sha256: ed02fdc457849b62d65c9a6ce012df977ddc09da26a4324bfcf4b588ea8b1b24
 
 build:
   number: 0
   # nodejs currently isn't available on s390x
-  skip: True  # [py<38 or s390x]
+  skip: True  # [py<39 or s390x]
   entry_points:
     - panel = panel.command:main
   script:
@@ -26,8 +26,7 @@ requirements:
     - wheel
     # These are also needed at build time.
     - bleach 4.1.0
-    - bokeh 3.1.1 # [py<39]
-    - bokeh 3.2.0 # [py>=39]
+    - bokeh 3.3.0 # [py>=39]
     - pyct 0.5.0
     - param 1.13.0
     - pyviz_comms 2.3.0
@@ -38,9 +37,9 @@ requirements:
     - python
     - bleach
     - packaging
-    - bokeh >=3.1.1,<3.3
+    - bokeh >=3.2.0,<3.4
     - markdown
-    - param >=1.12.0
+    - param >=2.0.0,<3
     - pyviz_comms >=0.7.4
     - requests
     - tqdm >=4.48.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - bleach 4.1.0
     - bokeh 3.3.0
     - pyct 0.5.0
-    - param 1.13.0
+    - param 2.0.0
     - pyviz_comms 2.3.0
     - nodejs 16.13.1
     - requests 2.31.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - wheel
     # These are also needed at build time.
     - bleach 4.1.0
-    - bokeh 3.3.0 # [py>=39]
+    - bokeh 3.3.0
     - pyct 0.5.0
     - param 1.13.0
     - pyviz_comms 2.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - pandas >=1.2
     - packaging
   run_constrained:
-    - holoviews >=1.16.0
+    - holoviews >=1.17.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: ed02fdc457849b62d65c9a6ce012df977ddc09da26a4324bfcf4b588ea8b1b24
+  sha256: 30e1ad012dc3c0367f018d9260abd55fb5de48be0892ddb3f88b137825e5c84a
 
 build:
   number: 0


### PR DESCRIPTION
Simple version bump with some updated pins, including dropping of python 3.8 support.