### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.0" %}
+{% set version = "1.3.1" %}
 
 package:
   name: panel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: 30e1ad012dc3c0367f018d9260abd55fb5de48be0892ddb3f88b137825e5c84a
+  sha256: d50abe3361239516b265444fef3a3c9f2faa0b0cfb671849c767829b857c7a5f
 
 build:
   number: 0


### PR DESCRIPTION
Very simple version bump, no dependencies changed so this should be uncontroversial.