### PR TITLE
Update to 1.3.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - bokeh 3.3.3
     - pyct 0.5.0
     - param 2.0
-    - pyviz_comms
+    - pyviz_comms 3.0.0
     - nodejs 18.16.0
     - requests 2.31.0
     - tqdm 4.65.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.1" %}
+{% set version = "1.3.7" %}
 
 package:
   name: panel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: d50abe3361239516b265444fef3a3c9f2faa0b0cfb671849c767829b857c7a5f
+  sha256: f572ceb6cb37982c3aaec63f2078860eeab93a3c757ebdcc9800bf1f06bcec2e
 
 build:
   number: 0
@@ -25,10 +25,9 @@ requirements:
     - setuptools
     - wheel
     # These are also needed at build time.
-    - bleach 4.1.0
-    - bokeh 3.3.0
+    - bokeh 3.3.3
     - pyct 0.5.0
-    - param 2.0.0
+    - param 2.0.1
     - pyviz_comms 2.3.0
     - nodejs 16.13.1
     - requests 2.31.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,10 +25,10 @@ requirements:
     - setuptools
     - wheel
     # These are also needed at build time.
-    - bokeh >=3.2.0,<3.4
+    - bokeh >=3.3.0,<3.4
     - pyct >=0.4.4
     - param >=2.0.0,<3
-    - pyviz_comms >=0.7.4
+    - pyviz_comms >=2.0.0
     - nodejs 18.16
     - requests
     - tqdm >=4.48.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,13 +25,13 @@ requirements:
     - setuptools
     - wheel
     # These are also needed at build time.
-    - bokeh 3.3.3
+    - bokeh >=3.2.0,<3.4
     - pyct 0.5.0
-    - param 2.0
-    - pyviz_comms 3.0.0
-    - nodejs 18.16.0
-    - requests 2.31.0
-    - tqdm 4.65.0
+    - param >=2.0.0,<3
+    - pyviz_comms >=0.7.4
+    - nodejs 18.16
+    - requests
+    - tqdm >=4.48.0
   run:
     - python
     - bokeh >=3.2.0,<3.4
@@ -77,3 +77,4 @@ extra:
     - philippjfr
   skip-lints:
     - python_build_tool_in_run
+    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - wheel
     # These are also needed at build time.
     - bokeh >=3.2.0,<3.4
-    - pyct 0.5.0
+    - pyct >=0.4.4
     - param >=2.0.0,<3
     - pyviz_comms >=0.7.4
     - nodejs 18.16
@@ -36,7 +36,7 @@ requirements:
     - python
     - bokeh >=3.2.0,<3.4
     - param >=2.0.0,<3
-    - pyviz_comms >=0.7.4
+    - pyviz_comms >=2.0.0
     - markdown
     - markdown-it-py
     - linkify-it-py


### PR DESCRIPTION
panel 1.3.7

**Destination channel:** defaults

### Explanation of changes:

Updates the recipe to Panel 1.3.7 and drops bleach as a build dependency since it is no longer needed.
