### PR TITLE
Bump 1.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - wheel
     # These are also needed at build time.
     - bokeh >=3.4.0,<3.5
-    - markdown =3.6
+    - markdown
     - pyct >=0.4.4
     - param >=2.0.0,<3
     - pyviz_comms >=2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.0" %}
+{% set version = "1.4.1" %}
 
 package:
   name: panel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: c2129d9d387423fa9f385600b945fe5279d0772f2ffa65c953e7139aee8ea01a
+  sha256: 1ad2084e65d4f0fc424432a963c9a4d668d8315203b338830b40c112ead3ebb7
 
 build:
   number: 0
@@ -26,6 +26,7 @@ requirements:
     - wheel
     # These are also needed at build time.
     - bokeh >=3.4.0,<3.5
+    - markdown =3.6
     - pyct >=0.4.4
     - param >=2.0.0,<3
     - pyviz_comms >=2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.8" %}
+{% set version = "1.4.0" %}
 
 package:
   name: panel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/panel/panel-{{ version }}.tar.gz
-  sha256: 809afd2b861747a31d6ddaadbbc7c25b8dab392dc78256f68b759214113c5be3
+  sha256: c2129d9d387423fa9f385600b945fe5279d0772f2ffa65c953e7139aee8ea01a
 
 build:
   number: 0
@@ -25,7 +25,7 @@ requirements:
     - setuptools
     - wheel
     # These are also needed at build time.
-    - bokeh >=3.3.0,<3.4
+    - bokeh >=3.4.0,<3.5
     - pyct >=0.4.4
     - param >=2.0.0,<3
     - pyviz_comms >=2.0.0
@@ -34,7 +34,7 @@ requirements:
     - tqdm >=4.48.0
   run:
     - python
-    - bokeh >=3.2.0,<3.4
+    - bokeh >=3.4.0,<3.5
     - param >=2.0.0,<3
     - pyviz_comms >=2.0.0
     - markdown
@@ -48,7 +48,7 @@ requirements:
     - pandas >=1.2
     - packaging
   run_constrained:
-    - holoviews >=1.17.0
+    - holoviews >=1.18.0
 
 test:
   imports:


### PR DESCRIPTION
`panel 1.4.1`

**Destination channel:** defaults

### Links

- [{ticket_number}]() 
- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:

### Explanation of changes:

Simple version bump to 1.4.1, also includes markdown as host dependency as it is imported during the build step.