### PR TITLE
Bump to 1.5.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "panel" %}
-{% set version = "1.5.2" %}
+{% set version = "1.5.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/panel-{{ version }}.tar.gz
-  sha256: 30a45f314716bdde2de5c002fbd3a0b4d6ff85459e2179284df559455ff1534b
+  sha256: 1280ac768fa88b3bc19282be875c9ad5229cb08089540e9d800dcde62ac5effb
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
   run_constrained:
     - holoviews >=1.18.0
     # set bokeh-fastapi bounds as discussed in https://github.com/AnacondaRecipes/panel-feedstock/pull/39
-    - bokeh-fastapi >=0.1.1,<0.2
+    - bokeh-fastapi >=0.1.2,<0.2
 
 test:
   imports:


### PR DESCRIPTION
panel 1.5.3

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/panel)
- [Upstream changelog/diff](https://github.com/holoviz/panel/releases/tag/v1.5.3)
