### PR TITLE
PKG-16354 panel split output

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -2,3 +2,6 @@ anaconda_config_version: 1
 upstream_sources:
   - pypi:
       identifier: panel
+    packages:
+      - panel-core
+      - panel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.9.3" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
@@ -11,63 +11,85 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<310]
-  entry_points:
-    - panel = panel.command:main
-  script:
-    - {{ PYTHON }} -m pip install . -vv  --no-deps --no-build-isolation
 
-requirements:
-  host:
-    - pip
-    - python
-    - hatchling
-    - hatch-vcs
-    - param >=2.1.0
-    - bokeh >=3.8.0,<3.10.0
-    - pyviz_comms >=0.7.4
-    - requests
-    - packaging
-    - nodejs >=18
-  run:
-    - python
-    - bokeh >=3.7.0,<3.10.0
-    - param >=2.1.0,<3.0
-    - pyviz_comms >=2.0.0
-    - panel-material-ui >=0.10.0
-    - markdown
-    - markdown-it-py
-    - linkify-it-py
-    - mdit-py-plugins
-    - narwhals >=2
-    - requests
-    - nh3
-    - typing-extensions
-    - pandas >=1.2
-    - packaging
-    - tqdm
-  run_constrained:
-    - holoviews >=1.18.0
-    # set bokeh-fastapi bounds as discussed in https://github.com/AnacondaRecipes/panel-feedstock/pull/39
-    - bokeh-fastapi >=0.1.5,<0.2.0
+outputs:
+  - name: panel-core
+    build:
+      number: 0
+      skip: true  # [py<310]
+      entry_points:
+        - panel = panel.command:main
+      script:
+        - $PYTHON -m pip install . -vv  --no-deps --no-build-isolation # [unix]
+        - '"%PYTHON%" -m pip install . -vv  --no-deps --no-build-isolation' # [win]
+    requirements:
+      host:
+        - pip
+        - python
+        - hatchling
+        - hatch-vcs
+        - param >=2.1.0
+        - bokeh >=3.8.0,<3.10.0
+        - pyviz_comms >=0.7.4
+        - requests
+        - packaging
+        - nodejs >=18
+      run:
+        - python
+        - bokeh >=3.7.0,<3.10.0
+        - param >=2.1.0,<3.0
+        - pyviz_comms >=2.0.0
+        - markdown
+        - markdown-it-py
+        - linkify-it-py
+        - mdit-py-plugins
+        - narwhals >=2
+        - requests
+        - nh3
+        - typing-extensions
+        - pandas >=1.2
+        - packaging
+        - tqdm
+      run_constrained:
+        - holoviews >=1.18.0
+        - bokeh-fastapi >=0.1.5,<0.2.0
+    test:
+      imports:
+        - panel
+        - panel.io
+      requires:
+        - pip
+        - pytest >=7
+        - pytest-asyncio
+        - pytest-rerunfailures <16.0
+        - pytest-xdist
+        - esbuild
+        - nodejs >=18
+      commands:
+        - panel --help
+        - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+        - pytest --pyargs panel.tests --asyncio-mode=auto --log-cli-level=INFO -k "not test_autoreload_app_local_module"
 
-test:
-  imports:
-    - panel
-    - panel.io
-  requires:
-    - pip
-    - pytest >=7
-    - pytest-asyncio
-    - pytest-rerunfailures <16.0
-    - pytest-xdist
-    - esbuild
-    - nodejs
-  commands:
-    - pip check
-    - panel --help
-    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest --pyargs panel.tests --asyncio-mode=auto --log-cli-level=INFO -k "not test_autoreload_app_local_module"
+  - name: panel
+    build:
+      number: 1
+      skip: true  # [py<310]
+    requirements:
+      host:
+        - pip
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('panel-core', exact=True) }}
+        - panel-material-ui >=0.10.0
+    test:
+      imports:
+        - panel
+      requires:
+        - pip
+        - python
+      commands:
+        - pip check
 
 about:
   home: https://panel.holoviz.org
@@ -86,3 +108,10 @@ extra:
     - philippjfr
   skip-lints:
     - host_section_needs_exact_pinnings
+    # pip check is also intentionally omitted for panel-core
+    # because the upstream python metadata still requires panel-marerial-ui,
+    # which is installed by the full panel metapackage rather than the core package.
+    - missing_pip_check
+    # The output uses conda-build's inline build.script command syntax,
+    # while this lint rule expects outputs[].script to be a script file path.
+    - wrong_output_script_key


### PR DESCRIPTION
panel 1.9.3
 
**Destination channel:** defaults
 
### Links
 
- [PKG-16354](https://anaconda.atlassian.net/browse/PKG-16354)
- [Upstream repository](https://github.com/holoviz/panel)
 
### Explanation of changes:
 
- Split the recipe into "panel-core" and the "panel" metapackage.
- "panel-core" now contains the actual Panel package, CLI entry point, dependencies, and tests.
- The top-level "panel" package is now an implicit metapackage that depends on:
  - the exact matching "panel-core" build
  - "panel-material-ui >=0.10.0"
- This removes the circular dependency between "panel" and "panel-material-ui".
- Updated "anaconda.yaml" so that "panel-core" is tracked against the same PyPI upstream source.
- Added a lint exclusion for "missing_pip_check" because global tests are ignored for multi-output recipes, while the linter still expects "pip check" for the implicit metapackage.

[PKG-16354]: https://anaconda.atlassian.net/browse/PKG-16354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ